### PR TITLE
Modify project to multiple executios in VS2022 in Mac OS X

### DIFF
--- a/src/Kernel/API/Triton.WebAPI/Properties/launchSettings.json
+++ b/src/Kernel/API/Triton.WebAPI/Properties/launchSettings.json
@@ -11,7 +11,6 @@
   "profiles": {
     "Triton.Kernel.WebAPI": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7175;http://localhost:5047",

--- a/src/Presentation/Triton/Properties/launchSettings.json
+++ b/src/Presentation/Triton/Properties/launchSettings.json
@@ -10,7 +10,6 @@
   "profiles": {
     "Triton": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7185;http://localhost:5134",
       "environmentVariables": {


### PR DESCRIPTION
We removed the "dotnetRunMessage" option, in the launchSettings.json files of all executable projects; Triton.WebAPI and Triton, the web application.